### PR TITLE
Fix electron start error

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,8 @@
-const { app, BrowserWindow } = require('electron');
-const path = require('path');
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function createWindow() {
   const win = new BrowserWindow({

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge } = require('electron');
+import { contextBridge } from 'electron';
 
 contextBridge.exposeInMainWorld('api', {
   ping: () => 'pong',


### PR DESCRIPTION
## Summary
- convert electron scripts to ES module syntax

## Testing
- `npm test`
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_68534e11356483328a3c03e71091e2b7