### PR TITLE
Add editable task list with local persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Planner
 
-This is a minimal prototype of a modular planner. The UI is built with React and the app is wrapped in an Electron shell.
+This is a minimal prototype of a modular planner. The UI is built with React and the app is wrapped in an Electron shell. Tasks are persisted locally using `localStorage`.
 
 ## Development
 
@@ -16,3 +16,8 @@ npm start
 ```
 
 The project uses a simple in-memory agent system inspired by `agents.md`.
+
+## Features
+
+- Add, edit and delete tasks
+- Tasks are stored locally so they persist across restarts

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,17 +4,107 @@ import ScheduleAgent from './agents/ScheduleAgent';
 
 export default function App() {
   const taskAgent = React.useMemo(() => new TaskManagerAgent(), []);
-  const scheduleAgent = React.useMemo(() => new ScheduleAgent(taskAgent), [taskAgent]);
+  const scheduleAgent = React.useMemo(
+    () => new ScheduleAgent(taskAgent),
+    [taskAgent]
+  );
+
+  const [tasks, setTasks] = React.useState(scheduleAgent.getTasks());
+  const [newTitle, setNewTitle] = React.useState('');
+  const [editingId, setEditingId] = React.useState(null);
+  const [editingText, setEditingText] = React.useState('');
+
+  React.useEffect(() => {
+    taskAgent.addChangeListener(() => setTasks([...scheduleAgent.getTasks()]));
+    // initialize state from persistence
+    setTasks(scheduleAgent.getTasks());
+  }, [taskAgent, scheduleAgent]);
+
+  const handleAdd = () => {
+    if (newTitle.trim()) {
+      taskAgent.addTask(newTitle.trim());
+      setNewTitle('');
+    }
+  };
+
+  const startEdit = (task) => {
+    setEditingId(task.id);
+    setEditingText(task.title);
+  };
+
+  const saveEdit = () => {
+    taskAgent.updateTask(editingId, editingText);
+    setEditingId(null);
+    setEditingText('');
+  };
+
+  const cancelEdit = () => {
+    setEditingId(null);
+    setEditingText('');
+  };
+
+  const deleteTask = (id) => {
+    taskAgent.deleteTask(id);
+  };
 
   return (
-    <div className="p-4 font-sans">
-      <h1 className="text-2xl font-bold mb-4">Planner</h1>
-      <div>
-        <button onClick={() => taskAgent.addTask('New Task')}>Add Task</button>
+    <div className="p-4 font-sans max-w-lg mx-auto">
+      <h1 className="text-3xl font-bold mb-4 text-center">Planner</h1>
+      <div className="flex mb-4 gap-2">
+        <input
+          className="border rounded px-2 py-1 flex-grow"
+          placeholder="New task"
+          value={newTitle}
+          onChange={(e) => setNewTitle(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleAdd();
+          }}
+        />
+        <button
+          className="bg-blue-500 text-white px-3 py-1 rounded"
+          onClick={handleAdd}
+        >
+          Add
+        </button>
       </div>
-      <ul>
-        {scheduleAgent.getTasks().map((t) => (
-          <li key={t.id}>{t.title}</li>
+      <ul className="space-y-2">
+        {tasks.map((t) => (
+          <li
+            key={t.id}
+            className="border rounded p-2 flex items-center justify-between"
+          >
+            {editingId === t.id ? (
+              <>
+                <input
+                  className="border rounded px-2 py-1 flex-grow mr-2"
+                  value={editingText}
+                  onChange={(e) => setEditingText(e.target.value)}
+                />
+                <button className="text-green-600 mr-2" onClick={saveEdit}>
+                  Save
+                </button>
+                <button className="text-gray-600" onClick={cancelEdit}>
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="flex-grow">{t.title}</span>
+                <button
+                  className="text-blue-600 mr-2"
+                  onClick={() => startEdit(t)}
+                >
+                  Edit
+                </button>
+                <button
+                  className="text-red-600"
+                  onClick={() => deleteTask(t.id)}
+                >
+                  Delete
+                </button>
+              </>
+            )}
+          </li>
         ))}
       </ul>
     </div>

--- a/src/agents/TaskManagerAgent.js
+++ b/src/agents/TaskManagerAgent.js
@@ -1,13 +1,44 @@
+import PersistenceAgent from './PersistenceAgent';
+
 export default class TaskManagerAgent {
-  constructor() {
-    this.tasks = [];
-    this.counter = 1;
+  constructor(persistence = new PersistenceAgent()) {
+    this.persistence = persistence;
+    const saved = this.persistence.load('tasks') || [];
+    this.tasks = saved;
+    this.counter = this.tasks.reduce((m, t) => Math.max(m, t.id), 0) + 1;
+    this.listeners = [];
+  }
+
+  _emit() {
+    this.persistence.save('tasks', this.tasks);
+    this.listeners.forEach((l) => l(this.tasks));
+  }
+
+  addChangeListener(listener) {
+    this.listeners.push(listener);
   }
 
   addTask(title) {
     const task = { id: this.counter++, title };
     this.tasks.push(task);
+    this._emit();
     return task;
+  }
+
+  updateTask(id, title) {
+    const task = this.tasks.find((t) => t.id === id);
+    if (task) {
+      task.title = title;
+      this._emit();
+    }
+  }
+
+  deleteTask(id) {
+    const idx = this.tasks.findIndex((t) => t.id === id);
+    if (idx !== -1) {
+      this.tasks.splice(idx, 1);
+      this._emit();
+    }
   }
 
   getTasks() {


### PR DESCRIPTION
## Summary
- persist tasks using PersistenceAgent
- add editing and deleting UI for tasks
- enhance App UI using Tailwind
- document new features in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68534f65aa288332857653ad470cdefa