### PR TITLE
Load categories from json

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -1,0 +1,25 @@
+{
+  "buckets": {
+    "now": "🔥 Now",
+    "next": "🌓 Next",
+    "later": "🌱 Later",
+    "someday": "💤 Someday",
+    "incubator": "🧪 Incubator"
+  },
+  "altitudes": {
+    "vision": "40k – Vision",
+    "domain": "20k – Domain",
+    "objective": "10k – Objective",
+    "project": "5k – Project",
+    "task": "Runway"
+  },
+  "domains": [
+    "Health",
+    "Career",
+    "Finance",
+    "Learning",
+    "Life Admin",
+    "Home Maintenance",
+    "General"
+  ]
+}


### PR DESCRIPTION
## Summary
- centralize bucket, altitude and domain definitions in `categories.json`
- fetch category data at runtime so editing the JSON file updates the UI automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68579b9fd34083328e90bf956edb7602